### PR TITLE
Add metadata to COD products

### DIFF
--- a/script/productize.py
+++ b/script/productize.py
@@ -73,7 +73,7 @@ def parse_start_end_times(base):
 
 def create_met(base, fn1, fn2):
     master_slcp_metfile = os.path.join(fn1, fn1 + '.met.json')
-    master_slcp_met = load_file(master_slcp_metfile)
+    master_slcp_met = load_json(master_slcp_metfile)
     met = {}
     met.update(parse_start_end_times(base))
     wanted_slcp_keys = ['trackNumber','frameID', 'swath', 'direction', 'lookDirection', 'spacecraftName']

--- a/script/productize.py
+++ b/script/productize.py
@@ -20,7 +20,7 @@ def main(prod_dir, fn1, fn2):
         print('Found no products available for publish in workdir: {}'.format(prod_dir))
         raise Exception('No COD products were generated.')
     base = os.path.basename(prod_dir)
-    met = create_met(base, fn1, fn)
+    met = create_met(base, fn1, fn2)
     dataset = {}
     dataset_path = os.path.join(prod_dir, '{0}.dataset.json'.format(base))
     met_path = os.path.join(prod_dir, '{0}.met.json'.format(base))

--- a/script/productize.py
+++ b/script/productize.py
@@ -71,7 +71,7 @@ def parse_start_end_times(base):
     return times
 
 def create_met(base, fn1, fn2):
-    master_slcp_metfile = os.path.join(fn1, fn1 + '.met.json')
+    master_slcp_metfile = os.path.join(fn1, os.path.basename(fn1) + '.met.json')
     master_slcp_met = load_json(master_slcp_metfile)
     met = {}
     met.update(parse_start_end_times(base))

--- a/script/productize.py
+++ b/script/productize.py
@@ -34,8 +34,7 @@ def main(prod_dir, fn1, fn2):
     dataset['dataset'] = 'S1-COD'
     dataset['label'] = base
     #parse starttime/endtime from name
-    dataset.update(met['starttime'])
-    dataset.update(met['endtime'])
+    dataset.update({'starttime':met['starttime'], 'endtime':met['endtime']})
 
     #parse info from context
     try:
@@ -144,9 +143,9 @@ def parser():
     @return argparse parser
     '''
     parse = argparse.ArgumentParser(description="Generate output COD met and dataset json")
-    parse.add_argument("prod_dir", help="COD product directory path")
     parse.add_argument("slcp_fn1", help="master SLCP path")
     parse.add_argument("slcp_fn2", help="slave SLCP path")
+    parse.add_argument("prod_dir", help="COD product directory path")
 
     return parse
 

--- a/script/slcp2cod_S1.sh
+++ b/script/slcp2cod_S1.sh
@@ -26,17 +26,17 @@ cd ${outdir}
 #get range/azimuth looks
 nm=$(basename ${dir1})
 metf=${dir1}/${nm}.met.json
-#rlooks=$(cat ${metf} | grep -Po '(?<="range_looks": )(.*?)(?=,)')
-#azlooks=$(cat ${metf} | grep -Po '(?<="azimuth_looks": )(.*?)(?=,)')
+rlooks=$(cat ${metf} | grep -Po '(?<="range_looks": )(.*?)(?=,)')
+azlooks=$(cat ${metf} | grep -Po '(?<="azimuth_looks": )(.*?)(?=,)')
 # range looks dependent on subswath
-azlooks=2
-if [ "${i}" -eq "1" ]; then
-    rlooks=7 #subswath 1
-elif [ "${i}" -eq "2" ]; then
-    rlooks=8 #subswath 2
-else
-    rlooks=9 #subswath 3
-fi
+#azlooks=2
+#if [ "${i}" -eq "1" ]; then
+#    rlooks=7 #subswath 1
+#elif [ "${i}" -eq "2" ]; then
+#    rlooks=8 #subswath 2
+#else
+#    rlooks=9 #subswath 3
+#fi
 
 
 

--- a/script/slcp2cod_wrapper.sh
+++ b/script/slcp2cod_wrapper.sh
@@ -32,7 +32,7 @@ subswath=$(grep -o "[1-3]" <<< $(grep -o "_s[1-3]-" <<< ${fn1}))
 ${script_dir}/slcp2cod_S1.sh ${fn1} ${fn2} ${fout}
 
 #productize
-${script_dir}/productize.py ${fout}
+${script_dir}/productize.py ${fn1} ${fn2} ${fout}
 
 #remove old dirs
 rm -rf ${fn1}


### PR DESCRIPTION
By request:
1.) it will be good to have track number displayed on FacetSearch.
2.) preference to have azimuth and looks follow SLCP, but it will be better if there are optional parameters to override and set the looks fo COD (to be addressed in separate PR)

Gists:
[stderr and stdout](https://gist.github.com/shitong01/cb9415c0478f372fe62551596f35841c)
[product](http://ntu-hysds-dataset.s3-website-ap-southeast-1.amazonaws.com/datasets/coherence_difference/v1.0/2019/04/24/S1-COD_M1S1_TN085_F223_S2_20190412T122027-20190424T122028-20190506T122055-v1.2-standard2)